### PR TITLE
Coin info section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,16 @@
 
 ### Summary
 
-`BIND` is the native currency of the Compendia blockchain. 
-The current circulation supply is around 110 million, about 65 million of which are currently stated. 
-See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
-The maximal supply is about 330 million. 
+ `BIND` is the native currency of the Compendia blockchain. 
+ The current circulation supply is around 110 million, about 65 million of which are currently stated. 
+ See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
+ The maximal supply is about 330 million. 
 
-`wBIND` is the same asset when wrapped to be used as an Ethereum token, see [etherscan](https://etherscan.io/address/0x15334dcb171e8b65d6650321581dca83be870115).
-For the market, see [coinmarketcap](https://coinmarketcap.com/currencies/wrapped-bind/), [coingecko](https://www.coingecko.com/en/coins/wrapped-bind)
+ `wBIND` is the same asset when wrapped to be used as an Ethereum token, see [etherscan](https://etherscan.io/address/0x15334dcb171e8b65d6650321581dca83be870115).
+ For the market, see [coinmarketcap](https://coinmarketcap.com/currencies/wrapped-bind/), [coingecko](https://www.coingecko.com/en/coins/wrapped-bind)
 
-`NOS` is the name of the currency from before the swap from NEO. See token swap section.
-Swapping is currently halted (Feb. 2020). Continuation will be announced.
+ `NOS` is the name of the currency from before the swap from NEO. See token swap section.
+ Swapping is currently halted (Feb. 2020). Continuation will be announced.
 
 ### Exchanges
 
@@ -118,7 +118,7 @@ Swapping is currently halted (Feb. 2020). Continuation will be announced.
         * [BIND/ETH](https://www.altilly.com/market/BIND_ETH) - BIND/ETH trading pair. Suspended due to hack.
         * [BIND/ARK](https://www.altilly.com/market/BIND_ARK) - BIND/ARK trading pair. Suspended due to hack.
         * [BIND/XQR](https://www.altilly.com/market/BIND_XQR) - BIND/XQR trading pair. Suspended due to hack.
-        
+
 ## Compendia Resources
 
 *Official Compendia Websites. Listed first due to relevance.*
@@ -258,7 +258,7 @@ Swapping is currently halted (Feb. 2020). Continuation will be announced.
         * [List Top Wallets](https://docs.compendia.org/api/wallets.html#list-all-top-wallets) - List all top wallets.
         * [Retrieve A Wallet](https://docs.compendia.org/api/wallets.html#retrieve-a-wallet) - Retrieve a wallet.
         * [Search All Wallets](https://docs.compendia.org/api/wallets.html#search-all-wallets) - Search all wallets.
-        
+
 ## Tools (Community)
 
 ***Unofficial** tools developed by Compendia community members.*

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 ### Summary
 
  `BIND` is the native currency of the Compendia blockchain. 
- The current circulation supply is around 110 million, about 65 million of which are currently stated. 
+ The current circulation supply is around 110 million, about 65 million of which are currently staked. 
  See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
  The maximal supply is about 330 million. 
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@
     - Validators
     - Token Swap
     - Wallet
-        
-- [Exchanges](#Exchanges)
-    - Altilly
-    - BIND.exchange
-    - Switcheo
     
 - [Mainnet API Documentation](#mainnet-api-documentation)
     - Blockchain
@@ -45,7 +40,14 @@
     - Transactions
     - Votes
     - Wallets
-
+        
+- [Token](#Token)
+    - [Summary](##Summary)
+    - [Exchanges](##Exchanges)
+       - BIND.exchange
+       - Switcheo
+       - Altilly
+      
 - [Tools (Community)](#tools-community)
     - Compendia JS - Javascript library for sending transactions - by mrmikeo
     - Compendia Crypto - Crypto npm library for Compendia - by mrmikeo
@@ -160,20 +162,6 @@
         * [Transfer](https://docs.compendia.org/guide/wallet.html#transfer) - Transfer.
         * [Voting](https://docs.compendia.org/guide/wallet.html#vote) - Voting.
 
-## Exchanges
-
-*Exchanges where BIND can be traded.*
-
-* [BIND.exchange](https://bind.exchange) - Uniswap portal for wBIND/ETH pool.
-* [Switcheo](https://switcheo.exchange/) - Switcheo Exchange paired with ETH.
-    * [wBIND/ETH](https://switcheo.exchange/markets/wBIND_ETH) - wBIND/ETH trading pair.
-* [Altilly (suspended due to hack)](https://altilly.com/) - Altilly Exchange paired with BTC, ETH, ARK & XQR.
-    * [Asset information](https://www.altilly.com/asset/BIND) - General information about BIND and it's trading pairs.
-        * [BIND/BTC](https://www.altilly.com/market/BIND_BTC) - BIND/BTC trading pair. Suspended due to hack.
-        * [BIND/ETH](https://www.altilly.com/market/BIND_ETH) - BIND/ETH trading pair. Suspended due to hack.
-        * [BIND/ARK](https://www.altilly.com/market/BIND_ARK) - BIND/ARK trading pair. Suspended due to hack.
-        * [BIND/XQR](https://www.altilly.com/market/BIND_XQR) - BIND/XQR trading pair. Suspended due to hack.
-
 ## Mainnet API Documentation
 
 *Official Compendia Mainnet API Documentation.*
@@ -240,6 +228,35 @@
         * [Retrieve A Wallet](https://docs.compendia.org/api/wallets.html#retrieve-a-wallet) - Retrieve a wallet.
         * [Search All Wallets](https://docs.compendia.org/api/wallets.html#search-all-wallets) - Search all wallets.
 
+## Token
+
+### Summary
+
+`BIND` is the native token of the Compendia blockchain. 
+The current circulation supply is around 110 million, about 65 million of which are currently stated. 
+See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
+The maximal supply is about 330 million. 
+
+`wBIND` is the same token when wrapped to be used as an Ethereum token, see [etherscan](https://etherscan.io/address/0x15334dcb171e8b65d6650321581dca83be870115).
+For the market, see [coinmarketcap](https://coinmarketcap.com/currencies/wrapped-bind/), [coingecko](https://www.coingecko.com/en/coins/wrapped-bind)
+
+`NOS` is the currency from before the token swap from NEO. See token swap section.
+Swapping is currently halted (Feb. 2020). Continuation will be announced.
+
+### Exchanges
+
+*Exchanges where wBIND can be traded.*
+
+* [BIND.exchange](https://bind.exchange) - Uniswap portal for wBIND/ETH pool.
+* [Switcheo](https://switcheo.exchange/) - Switcheo Exchange paired with ETH.
+    * [wBIND/ETH](https://switcheo.exchange/markets/wBIND_ETH) - wBIND/ETH trading pair.
+* [Altilly (suspended due to hack)](https://altilly.com/) - Altilly Exchange paired with BTC, ETH, ARK & XQR.
+    * [Asset information](https://www.altilly.com/asset/BIND) - General information about BIND and it's trading pairs.
+        * [BIND/BTC](https://www.altilly.com/market/BIND_BTC) - BIND/BTC trading pair. Suspended due to hack.
+        * [BIND/ETH](https://www.altilly.com/market/BIND_ETH) - BIND/ETH trading pair. Suspended due to hack.
+        * [BIND/ARK](https://www.altilly.com/market/BIND_ARK) - BIND/ARK trading pair. Suspended due to hack.
+        * [BIND/XQR](https://www.altilly.com/market/BIND_XQR) - BIND/XQR trading pair. Suspended due to hack.
+        
 ## Tools (Community)
 
 ***Unofficial** tools developed by Compendia community members.*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 ## Contents
 
 - [Coin](#Coin)
-    - [Summary](#Coin##Summary)
-    - [Exchanges](#Coin##Exchanges)
+    - Summary
+    - Exchanges
        - BIND.exchange
        - Switcheo
        - Altilly

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 
 ## Contents
 
+- [Coin](#Coin)
+    - [Summary](#Coin##Summary)
+    - [Exchanges](#Coin##Exchanges)
+       - BIND.exchange
+       - Switcheo
+       - Altilly
+
 - [Compendia Resources](#compendia-resources)
     - Websites*
     - GitHub
@@ -40,13 +47,6 @@
     - Transactions
     - Votes
     - Wallets
-        
-- [Token](#Token)
-    - [Summary](##Summary)
-    - [Exchanges](##Exchanges)
-       - BIND.exchange
-       - Switcheo
-       - Altilly
       
 - [Tools (Community)](#tools-community)
     - Compendia JS - Javascript library for sending transactions - by mrmikeo
@@ -88,6 +88,37 @@
         - Compendia Tools - by arbaro
         - Compendia Validators Info - by the_bobbie_bunch
 
+----
+
+## Coin
+
+### Summary
+
+`BIND` is the native currency of the Compendia blockchain. 
+The current circulation supply is around 110 million, about 65 million of which are currently stated. 
+See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
+The maximal supply is about 330 million. 
+
+`wBIND` is the same asset when wrapped to be used as an Ethereum token, see [etherscan](https://etherscan.io/address/0x15334dcb171e8b65d6650321581dca83be870115).
+For the market, see [coinmarketcap](https://coinmarketcap.com/currencies/wrapped-bind/), [coingecko](https://www.coingecko.com/en/coins/wrapped-bind)
+
+`NOS` is the name of the currency from before the swap from NEO. See token swap section.
+Swapping is currently halted (Feb. 2020). Continuation will be announced.
+
+### Exchanges
+
+*Exchanges where wBIND can be traded.*
+
+* [BIND.exchange](https://bind.exchange) - Uniswap portal for wBIND/ETH pool.
+* [Switcheo](https://switcheo.exchange/) - Switcheo Exchange paired with ETH.
+    * [wBIND/ETH](https://switcheo.exchange/markets/wBIND_ETH) - wBIND/ETH trading pair.
+* [Altilly (suspended due to hack)](https://altilly.com/) - Altilly Exchange paired with BTC, ETH, ARK & XQR.
+    * [Asset information](https://www.altilly.com/asset/BIND) - General information about BIND and it's trading pairs.
+        * [BIND/BTC](https://www.altilly.com/market/BIND_BTC) - BIND/BTC trading pair. Suspended due to hack.
+        * [BIND/ETH](https://www.altilly.com/market/BIND_ETH) - BIND/ETH trading pair. Suspended due to hack.
+        * [BIND/ARK](https://www.altilly.com/market/BIND_ARK) - BIND/ARK trading pair. Suspended due to hack.
+        * [BIND/XQR](https://www.altilly.com/market/BIND_XQR) - BIND/XQR trading pair. Suspended due to hack.
+        
 ## Compendia Resources
 
 *Official Compendia Websites. Listed first due to relevance.*
@@ -227,35 +258,6 @@
         * [List Top Wallets](https://docs.compendia.org/api/wallets.html#list-all-top-wallets) - List all top wallets.
         * [Retrieve A Wallet](https://docs.compendia.org/api/wallets.html#retrieve-a-wallet) - Retrieve a wallet.
         * [Search All Wallets](https://docs.compendia.org/api/wallets.html#search-all-wallets) - Search all wallets.
-
-## Token
-
-### Summary
-
-`BIND` is the native token of the Compendia blockchain. 
-The current circulation supply is around 110 million, about 65 million of which are currently stated. 
-See also [Explorer](https://bindscan.io/) in the Mainnet Resources section.
-The maximal supply is about 330 million. 
-
-`wBIND` is the same token when wrapped to be used as an Ethereum token, see [etherscan](https://etherscan.io/address/0x15334dcb171e8b65d6650321581dca83be870115).
-For the market, see [coinmarketcap](https://coinmarketcap.com/currencies/wrapped-bind/), [coingecko](https://www.coingecko.com/en/coins/wrapped-bind)
-
-`NOS` is the currency from before the token swap from NEO. See token swap section.
-Swapping is currently halted (Feb. 2020). Continuation will be announced.
-
-### Exchanges
-
-*Exchanges where wBIND can be traded.*
-
-* [BIND.exchange](https://bind.exchange) - Uniswap portal for wBIND/ETH pool.
-* [Switcheo](https://switcheo.exchange/) - Switcheo Exchange paired with ETH.
-    * [wBIND/ETH](https://switcheo.exchange/markets/wBIND_ETH) - wBIND/ETH trading pair.
-* [Altilly (suspended due to hack)](https://altilly.com/) - Altilly Exchange paired with BTC, ETH, ARK & XQR.
-    * [Asset information](https://www.altilly.com/asset/BIND) - General information about BIND and it's trading pairs.
-        * [BIND/BTC](https://www.altilly.com/market/BIND_BTC) - BIND/BTC trading pair. Suspended due to hack.
-        * [BIND/ETH](https://www.altilly.com/market/BIND_ETH) - BIND/ETH trading pair. Suspended due to hack.
-        * [BIND/ARK](https://www.altilly.com/market/BIND_ARK) - BIND/ARK trading pair. Suspended due to hack.
-        * [BIND/XQR](https://www.altilly.com/market/BIND_XQR) - BIND/XQR trading pair. Suspended due to hack.
         
 ## Tools (Community)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
     - Transactions
     - Votes
     - Wallets
-      
+
 - [Tools (Community)](#tools-community)
     - Compendia JS - Javascript library for sending transactions - by mrmikeo
     - Compendia Crypto - Crypto npm library for Compendia - by mrmikeo

--- a/awesome-blog/CompendiaCommunityFund_Proposal.md
+++ b/awesome-blog/CompendiaCommunityFund_Proposal.md
@@ -5,7 +5,7 @@ This is a proposal to the community and the validators that support Compendia.
 
 - The Compendia Community Fund (CCF) is a fund that is run by the Compendia community members. It can be seen as supplemental to the core development of the Compendia ecosystem and shall support the ideas and projects of community members to help promote the advancement of the wider ecosystem. 
 
-- It aims (1) to provide a possibility to those Compendia community members that would like to support the ecosystem with contributions of BIND tokens for community purposes and (2) to provide a place for community developers to request funding, for projects to develop tools, software or hardware which helps to improve, support and add value to the ecosystem.
+- It aims (1) to provide a possibility to those Compendia community members that would like to support the ecosystem with contributions of BIND coins for community purposes and (2) to provide a place for community developers to request funding, for projects to develop tools, software or hardware which helps to improve, support and add value to the ecosystem.
 
 - The CCF will be run by Compendia community members - being a validator is not required.
 
@@ -35,7 +35,7 @@ This is a proposal to the community and the validators that support Compendia.
 
 The CCF has two main purposes: 
 
-- First, is to provide a possibility to those Compendia community members that would like to support the Ecosystem with contributions of BIND tokens for community purposes. Funds will be held in a multi-signature address using the ARK desktop wallet feature.
+- First, is to provide a possibility to those Compendia community members that would like to support the Ecosystem with contributions of BIND coins for community purposes. Funds will be held in a multi-signature address using the ARK desktop wallet feature.
 
 - Second, to provide a place for community developers to request funding, for projects to develop tools, software or hardware which helps to improve, support and add value to the ecosystem.
 
@@ -69,7 +69,7 @@ The CCF has two main purposes:
 
 ### How will the Compendia Team be involved in the Fund?
 
-- As the CCF is completely separate from the Compendia Team. They will not be a part of the management or final decision making of the CCF. Nor will they have access to, or own a share of the collected BIND held by the CCF.
+- As the CCF is completely separate from the Compendia Team, they will not be a part of the management or final decision making of the CCF. Nor will they have access to, or own a share of the collected BIND held by the CCF.
 
 - However, they can provide valuable input on projects and the overall direction of Compendia development. So the idea is to create an Advisory Board with 2 members of the Compendia team. These members can provide recommendations and/or input on projects and proposals. It would be positive to have one member with a development/coding background for any technical questions on the projects.  Also to ensure no duplication of effort by the community developers and Compendia team.
 
@@ -155,7 +155,7 @@ The CCF has two main purposes:
 
 The project proposer submits a proposal covering the phases defined below.  A template/ webform will be provided.
 
-- Phase 0 – Requirements Gathering/Terms of Reference (TOR)
+- Phase 0 – Requirements Gathering/[Terms of Reference](https://en.wikipedia.org/wiki/Terms_of_reference) (TOR)
 - Phase 1 - Cost-Benefit Analysis
 - Phase 2 – Proof of Concept
 - Phase 3 – Detailed Design
@@ -199,7 +199,7 @@ PP’s will need to provide updates at each stage.
 
 - Marketing/Banners/Tweets et cetera to support launch of CCF
 
-- A CCF Logo
+- A CCF logo
 
 - Website design, requirements are:
     - Make website

--- a/awesome-blog/Staking.md
+++ b/awesome-blog/Staking.md
@@ -50,7 +50,7 @@ The key difference is that staked coins are locked for a fixed period, either 3,
 
 At the time of writing, ß11,816,021 is currently locked into staking, given the current BIND supply (i.e nOS to BIND) ß112,894,676, around 10% of all BIND in circulation is locked out of supply for the staking periods highlighted earlier. With the current staked coins, it would take just over 6 months for inflation to offset the monthly forging reward increase.
 
-## Fee removal model.
+## Fee removal model
 Compendia also offer another deflationary measure through a sophisticated fee removal model.
 
 #### The [fee collection and removal model](https://docs.compendia.org/guide/economy.html#fee-removal-model) works as follows:


### PR DESCRIPTION
Turns the Exchange section into a Coin section of which Exchange is a subsection. 
Adds a summary with basic plaintext token info so one can link to it.